### PR TITLE
Upgrading PMD version with latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,9 +26,9 @@ dependencies {
     implementation("info.picocli:picocli-spring-boot-starter:4.5.1") {
         exclude module: "spring-boot-starter-logging"
     }
-    implementation 'net.sourceforge.pmd:pmd-java:6.13.0'
-    implementation 'net.sourceforge.pmd:pmd-cpp:6.13.0'
-    implementation 'net.sourceforge.pmd:pmd-jsp:6.13.0'
+    implementation 'net.sourceforge.pmd:pmd-java:6.30.0'
+    implementation 'net.sourceforge.pmd:pmd-cpp:6.30.0'
+    implementation 'net.sourceforge.pmd:pmd-jsp:6.30.0'
     implementation 'javax.validation:validation-api:2.0.1.Final'
     implementation 'org.hibernate.validator:hibernate-validator:6.1.0.Final'
     implementation 'org.hibernate.validator:hibernate-validator-annotation-processor:6.1.0.Final'

--- a/src/test/java/com/philips/swcoe/cerberus/CerberusTest.java
+++ b/src/test/java/com/philips/swcoe/cerberus/CerberusTest.java
@@ -48,7 +48,7 @@ public class CerberusTest extends CerberusBaseTest {
     }
 
     @Test
-    @ExpectSystemExitWithStatus(18)
+    @ExpectSystemExitWithStatus(15)
     public void shouldReturnExitStatusAsNumberOfViolationsForPMDAnyHound() {
         getOriginalOutputStream().flush();
         Cerberus.main(new String[] {"FPM", "--files", badCodePath, "--language", "JAVA", "--java-version", "8", "--rulesets", externalRuleSet});

--- a/src/test/java/com/philips/swcoe/cerberus/hounds/FindProgrammingMistakesTest.java
+++ b/src/test/java/com/philips/swcoe/cerberus/hounds/FindProgrammingMistakesTest.java
@@ -63,7 +63,7 @@ class FindProgrammingMistakesTest extends BaseCommandTest {
         executeFindProgrammingMistakes(findProgrammingMistakes, path, "java", "8",
             externalRuleSet);
         assertTrue(getModifiedOutputStream().toString()
-            .contains("Found 18 violations in the specified source path"));
+            .contains("Found 15 violations in the specified source path"));
         assertTrue(new File(path + PATH_SEPARATOR + "mistakes-report.html").exists());
     }
 


### PR DESCRIPTION
PMD latest version has some new Dead code rules such as [unusedassignment](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#unusedassignment). To allow people to use them I am upgrading PMD to latest version. 

Some of the rules are depricated and that is the reason our test needs to be modified . 